### PR TITLE
Allow animals to be requested by a list of ids, resolves #94

### DIFF
--- a/src/schema/resolvers/animal.ts
+++ b/src/schema/resolvers/animal.ts
@@ -68,8 +68,8 @@ async function getUpdateMicrochipResult(input: any, pgClient: any) {
 
 const resolvers: IResolvers = {
     Query: {
-        animals: async (_, __, { pgClient }) => {
-            const dbResponse = await pgClient.query(getAnimalsQuery());
+        animals: async (_, { ids }, { pgClient }) => {
+            const dbResponse = await pgClient.query(getAnimalsQuery(ids));
             return dbResponse.rows;
         },
         animal: async (_, { id }, { pgClient }) => {

--- a/src/schema/typeDefs/animal.graphql
+++ b/src/schema/typeDefs/animal.graphql
@@ -15,7 +15,7 @@ extend type Query {
 
     animals
     """
-    animals: [Animal]
+    animals(ids: [Int!]): [Animal]
 }
 
 "Represents an animal."

--- a/src/sql-queries/animal.ts
+++ b/src/sql-queries/animal.ts
@@ -56,19 +56,19 @@ export const getAnimalQuery = (id: number): QueryConfig => {
     return query;
 };
 
-export const getAnimalsQuery = (): QueryConfig => {
-    const text = `SELECT
-                    id,
-                    name,
-                    organization,
-                    status,
-                    image_url,
-                    comments,
-                    mod_time
-                FROM ${table};`;
-
+export const getAnimalsQuery = (ids: [number] | null): QueryConfig => {
+    const text = `SELECT id,
+                         name,
+                         organization,
+                         status,
+                         image_url,
+                         comments,
+                         mod_time
+                  FROM ${table}
+                  WHERE $1::int[] IS NULL OR id = ANY ($1);`;
     const query = {
         text,
+        values: [ids]
     };
 
     return query;

--- a/test/animal.graphql.test.ts
+++ b/test/animal.graphql.test.ts
@@ -57,6 +57,34 @@ describe('GraphQL animal integration tests', () => {
                 return done();
             });
     });
+
+    it('Returns animals by array of ids [1,2,3] with all fields', (done) => {
+        request
+            .post('/graphql')
+            .send({
+                query: `{ animals (ids: [1,2,3])
+                      ${animalFields}
+                  }`,
+            })
+            .set('Authorization', `Bearer ${process.env.BEARER_TOKEN}`)
+            .expect(200)
+            .end((err, res) => {
+                if (err) {
+                    // eslint-disable-next-line no-console
+                    console.log(res.body);
+                    return done(err);
+                }
+                const {
+                    body: {
+                        data: { animals },
+                    },
+                } = res;
+                expect(animals).to.be.an('array');
+                validate(animals[0]);
+                expect(animals).to.have.length(3);
+                return done();
+            });
+    });
 });
 
 describe('animal mutations tests', () => {


### PR DESCRIPTION
A. Such input

```
{
    animals(ids: [1,2,3]) {
        name
  }
}
```

B. Input without any animal ids specified - IT WILL NOT WORK with empty parenthesis

BAD
```
{
    animals() {
        name
  }
}
```

OK
```
{
    animals {
        name
  }
}
```

