### PR TITLE
#244 Create table for Microchipping event details

### DIFF
--- a/database/1-schema.sql
+++ b/database/1-schema.sql
@@ -212,7 +212,7 @@ CREATE TYPE chip_status AS ENUM ('Implanted', 'Removed');
 
 CREATE TABLE animal_microchip (
     animal_id INTEGER REFERENCES animal(id) ON DELETE CASCADE NOT NULL,
-    microchip_id VARCHAR(255) NOT NULL,
+    microchip_id VARCHAR(255) NOT NULL UNIQUE,
     chip_company_code chip_company_code NOT NULL,
     install_date DATE,
     install_place_id install_place_id NOT NULL,
@@ -353,6 +353,11 @@ CREATE TABLE event_location_change_details (
     house_no VARCHAR(8),
     municipality_id INTEGER REFERENCES municipality(id) NOT NULL,
     mod_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE microchipping_event_details (
+    event_id INTEGER PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE NOT NULL,
+    microchip_id VARCHAR(255) REFERENCES animal_microchip(microchip_id) ON DELETE CASCADE NOT NULL
 );
 
 -- DATE UPDATES

--- a/database/3-fake-data.sql
+++ b/database/3-fake-data.sql
@@ -212,3 +212,11 @@ INSERT INTO animal_cage (animal_id, cage_id) VALUES
 (2, 4),
 (3, 5),
 (4, 6);
+
+INSERT INTO microchipping_event_details
+(event_id, microchip_id) VALUES
+(1, '123'),
+(2, '666666'),
+(5, '001010101'),
+(4, '29387'),
+(3, '2893402');


### PR DESCRIPTION
Added new table `microchipping_event_details` and some fake data.

I had to make `microchip_id` column in `animal_microchip` table `UNIQUE`, because I get an error on Docker compose up command.

P. S. I think you made a typo in column name "microchipId" in the table structure.