### PR TITLE
Add possibility to send species creating or updating animal, closes #293

### DIFF
--- a/src/schema/typeDefs/animalDetails.graphql
+++ b/src/schema/typeDefs/animalDetails.graphql
@@ -35,6 +35,8 @@ type AnimalDetails {
 input AnimalDetailsInput {
     "Animal breed id (any value from 'breeds' query)"
     breedId: Int
+    "Species breed id (any value from 'species' query)"
+    speciesId: Int
     "Animal gender (any value from 'genders' query)"
     genderId: Int
     "Animal color (any value from 'colors' query)"

--- a/test/animal.graphql.test.ts
+++ b/test/animal.graphql.test.ts
@@ -428,6 +428,40 @@ describe('GraphQL animal mutations tests', () => {
             });
     });
 
+    it('Update animal details to given species unidentified breed', (done) => {
+        const mutation = 'updateAnimal';
+        const update = `{
+                id: 2,
+                details: {
+                    speciesId: 1
+                }
+        }`;
+        const answer = {'details.breed.id': 8881 };
+
+        let req = request
+            .post('/graphql')
+            .send({
+                query: `
+            mutation {
+                ${mutation}(input: ${update})
+                    ${animalFields}
+                }`,
+            });
+        if (process.env.BEARER_TOKEN) {
+            req = req.set('authorization', `Bearer ${process.env.BEARER_TOKEN}`)
+        }
+        req.expect(200)
+            .end((err, res) => {
+                if (err) {
+                    // eslint-disable-next-line no-console
+                    console.log(res.body);
+                    return done(err);
+                }
+                expect(res.body.data[mutation]).to.deep.nested.include(answer);
+                return done();
+            });
+    });
+
     it('Delete animal', (done) => {
         const mutation = 'deleteAnimal';
         const deleteInput = `{ id: ${animalId} }`;

--- a/test/animal.graphql.test.ts
+++ b/test/animal.graphql.test.ts
@@ -428,6 +428,40 @@ describe('GraphQL animal mutations tests', () => {
             });
     });
 
+    it('Create animal with given given species unidentified breed', (done) => {
+        const mutation = 'createAnimal';
+        const create = `{
+                  name: "Unindetified breed",
+                  details: {
+                    speciesId: 2
+                  },
+          }`;
+        const answer = {'details.breed.id': 8882 };
+
+        let req = request
+            .post('/graphql')
+            .send({
+                query: `
+                      mutation {
+                          ${mutation}(input: ${create})
+                          ${animalFields}
+                  }`,
+            });
+        if (process.env.BEARER_TOKEN) {
+            req = req.set('authorization', `Bearer ${process.env.BEARER_TOKEN}`)
+        }
+        req.expect(200)
+            .end((err, res) => {
+                if (err) {
+                    // eslint-disable-next-line no-console
+                    console.log(res.body);
+                    return done(err);
+                }
+                expect(res.body.data[mutation]).to.deep.nested.include(answer);
+                return done();
+            });
+    });
+
     it('Update animal details to given species unidentified breed', (done) => {
         const mutation = 'updateAnimal';
         const update = `{


### PR DESCRIPTION
`speciesId `and `breedId `are not required. Should any of these be required?

Query example changes breedId to 8881:
```
mutation {
  updateAnimal(input: { id: 1, details: { speciesId: 1 } }) {
    id
    details {
      breed {
        id
      }
      species {
        id
      }
    }
  }
}
```